### PR TITLE
redesign UI login

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,6 +5,8 @@
     <link rel="icon" type="image/png" href="/climbge.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Climbge</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Space+Grotesk:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/LoginPage.tsx
+++ b/frontend/src/LoginPage.tsx
@@ -1,16 +1,27 @@
 import { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
-import { Card, CardContent, CardHeader, CardTitle } from './components/ui/card';
-import { Button } from './components/ui/button';
-import { Input } from './components/ui/input';
-import { Label } from './components/ui/label';
-import { Alert, AlertDescription } from './components/ui/alert';
 import { apiLogin } from './lib/api';
-import { User, Lock, Eye, EyeOff, Mountain } from 'lucide-react';
+import { Eye, EyeOff } from 'lucide-react';
 import type { UserProfile } from './types/user';
 
 interface LoginPageProps {
   onLogin: (userProfile: UserProfile) => void;
+}
+
+// Decorative amber blob
+function Blob({ style }: { style: React.CSSProperties }) {
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        background: '#F7A62D',
+        borderRadius: '50%',
+        pointerEvents: 'none',
+        zIndex: 1,
+        ...style,
+      }}
+    />
+  );
 }
 
 export function LoginPage({ onLogin }: LoginPageProps) {
@@ -23,10 +34,8 @@ export function LoginPage({ onLogin }: LoginPageProps) {
   const handleLogin = async (e: React.FormEvent) => {
     e.preventDefault();
     setLoginError('');
-
     if (!username.trim()) return setLoginError('Please enter your username');
     if (!password.trim()) return setLoginError('Please enter your password');
-
     try {
       const res = await apiLogin(username.trim(), password);
       onLogin(res.profile);
@@ -37,95 +46,233 @@ export function LoginPage({ onLogin }: LoginPageProps) {
     }
   };
 
-  // small style helpers to match SignupPage
-  const fieldClass =
-    "pl-10 h-11 bg-brand/10 border border-brand/30 text-foreground " +
-    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40 focus-visible:border-brand " +
-    "placeholder:text-muted-foreground";
-  const iconClass = "absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-brand";
+  /* ── shared inline styles ── */
+  const inputStyle: React.CSSProperties = {
+    width: '100%',
+    background: 'rgba(255,255,255,0.07)',
+    border: '1px solid rgba(255,255,255,0.1)',
+    borderRadius: 10,
+    padding: '13px 14px 13px 42px',
+    color: '#fff',
+    fontSize: 15,
+    fontFamily: "'Space Grotesk', sans-serif",
+    outline: 'none',
+  };
 
-  return (
-    <div className="min-h-screen bg-gray-50 flex items-center justify-center px-4">
-      <div className="w-full max-w-md">
-        {/* Brand */}
-        <div className="text-center space-y-3 mb-6">
-          <div className="mx-auto w-16 h-16 bg-brand rounded-full flex items-center justify-center shadow-sm">
-            <Mountain className="h-8 w-8 text-white" />
-          </div>
-          <h1 className="text-2xl font-bold text-gray-800">Welcome back</h1>
-          <p className="text-gray-500 text-sm">Sign in to continue your climbing journey</p>
+  const labelStyle: React.CSSProperties = {
+    fontSize: 10,
+    fontWeight: 700,
+    letterSpacing: '0.16em',
+    textTransform: 'uppercase',
+    color: 'rgba(255,255,255,0.4)',
+    marginBottom: 6,
+    display: 'block',
+  };
+
+  const iconStyle: React.CSSProperties = {
+    position: 'absolute',
+    left: 14,
+    top: '50%',
+    transform: 'translateY(-50%)',
+    fontSize: 14,
+    color: 'rgba(247,166,45,0.65)',
+    pointerEvents: 'none',
+  };
+
+  /* ── MOBILE layout (< 768px) ── */
+  const MobileLayout = () => (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        minHeight: '100dvh',
+        background: '#fafaf9',
+        fontFamily: "'Space Grotesk', sans-serif",
+        overflow: 'hidden',
+      }}
+    >
+      {/* Hero top */}
+      <div style={{ position: 'relative', flexShrink: 0, overflow: 'hidden', padding: '44px 32px 16px' }}>
+        <Blob style={{ width: 180, height: 180, top: -60, right: -50, opacity: 0.13 }} />
+        <Blob style={{ width: 60, height: 60, top: '42%', left: -16, opacity: 0.09, borderRadius: '30% 60% 50% 40%', transform: 'rotate(20deg)' }} />
+        <Blob style={{ width: 32, height: 22, top: '28%', right: 72, opacity: 0.18, borderRadius: '50% 30% 60% 40%', transform: 'rotate(-15deg)' }} />
+
+        {/* Brand row */}
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 24, position: 'relative', zIndex: 2 }}>
+          <img src="/climbge.png" style={{ width: 32, height: 32, objectFit: 'contain' }} alt="climbge logo" />
+          <span style={{ fontFamily: "'Bebas Neue', sans-serif", fontSize: 20, letterSpacing: '0.12em', color: '#1c1917' }}>CLIMBGE</span>
         </div>
 
-        {/* Login */}
-        <Card className="border border-brand/20 bg-white shadow-xl rounded-2xl">
-          <CardHeader className="pb-0">
-            <CardTitle className="text-center text-lg">Sign In</CardTitle>
-          </CardHeader>
-          <CardContent className="pt-4">
-            <form onSubmit={handleLogin} className="space-y-4">
-              {/* Username */}
-              <div className="space-y-2">
-                <Label htmlFor="username">Username</Label>
-                <div className="relative">
-                  <User className={iconClass} />
-                  <Input
-                    id="username"
-                    type="text"
-                    placeholder="Enter your username"
-                    value={username}
-                    onChange={(e) => setUsername(e.target.value)}
-                    className={fieldClass}
-                  />
-                </div>
-              </div>
+        {/* Hero text */}
+        <div style={{ fontFamily: "'Bebas Neue', sans-serif", fontSize: 'clamp(72px, 22vw, 88px)', lineHeight: 0.87, color: '#1c1917', position: 'relative', zIndex: 2 }}>
+          CLIMB<br /><span style={{ color: '#F7A62D' }}>MORE.</span><br />LOG IT.
+        </div>
+        <div style={{ fontSize: 13, fontWeight: 500, color: '#78716c', marginTop: 12, position: 'relative', zIndex: 2, letterSpacing: '0.01em' }}>
+          Sign back in to keep your streak alive.
+        </div>
+      </div>
 
-              {/* Password */}
-              <div className="space-y-2">
-                <Label htmlFor="password">Password</Label>
-                <div className="relative">
-                  <Lock className={iconClass} />
-                  <Input
-                    id="password"
-                    type={showPassword ? 'text' : 'password'}
-                    placeholder="Enter your password"
-                    value={password}
-                    onChange={(e) => setPassword(e.target.value)}
-                    className={`${fieldClass} pr-10`}
-                  />
-                  <button
-                    type="button"
-                    onClick={() => setShowPassword((s) => !s)}
-                    className="absolute right-3 top-1/2 -translate-y-1/2 text-brand hover:opacity-80"
-                    aria-label={showPassword ? 'Hide password' : 'Show password'}
-                  >
-                    {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
-                  </button>
-                </div>
-              </div>
+      {/* Dark form sheet */}
+      <div style={{ flex: 1, background: '#1c1917', borderRadius: '28px 28px 0 0', padding: '28px 28px 0', overflowY: 'auto' }}>
+        <div style={{ marginBottom: 14 }} />
 
-              {/* Error */}
-              {loginError && (
-                <Alert className="border-destructive/50 bg-destructive/10">
-                  <AlertDescription className="text-destructive">{loginError}</AlertDescription>
-                </Alert>
-              )}
+        <form onSubmit={handleLogin}>
+          <label style={labelStyle}>Username</label>
+          <div style={{ position: 'relative', marginBottom: 14 }}>
+            <span style={iconStyle}>◉</span>
+            <input
+              style={inputStyle}
+              type="text"
+              placeholder="your handle"
+              value={username}
+              onChange={(e) => setUsername(e.target.value)}
+              onFocus={(e) => (e.target.style.borderColor = 'rgba(247,166,45,0.5)')}
+              onBlur={(e) => (e.target.style.borderColor = 'rgba(255,255,255,0.1)')}
+            />
+          </div>
 
-              {/* Actions */}
-              <div className="space-y-3">
-                <Button type="submit" className="w-full h-11 bg-brand hover:bg-brand-dark text-white">
-                  Sign In
-                </Button>
-                <p className="text-center text-sm text-gray-500">
-                  Don’t have an account?{' '}
-                  <Link to="/signup" className="text-brand hover:opacity-80 font-medium">
-                    Sign up
-                  </Link>
-                </p>
-              </div>
-            </form>
-          </CardContent>
-        </Card>
+          <label style={labelStyle}>Password</label>
+          <div style={{ position: 'relative', marginBottom: 20 }}>
+            <span style={iconStyle}>◈</span>
+            <input
+              style={{ ...inputStyle, paddingRight: 42 }}
+              type={showPassword ? 'text' : 'password'}
+              placeholder="••••••••"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              onFocus={(e) => (e.target.style.borderColor = 'rgba(247,166,45,0.5)')}
+              onBlur={(e) => (e.target.style.borderColor = 'rgba(255,255,255,0.1)')}
+            />
+            <button
+              type="button"
+              onClick={() => setShowPassword((s) => !s)}
+              style={{ position: 'absolute', right: 14, top: '50%', transform: 'translateY(-50%)', background: 'none', border: 'none', cursor: 'pointer', color: 'rgba(255,255,255,0.4)', padding: 0, display: 'flex', alignItems: 'center' }}
+              aria-label={showPassword ? 'Hide password' : 'Show password'}
+            >
+              {showPassword ? <EyeOff size={16} /> : <Eye size={16} />}
+            </button>
+          </div>
+
+          {loginError && (
+            <div style={{ background: 'rgba(239,68,68,0.12)', border: '1px solid rgba(239,68,68,0.3)', borderRadius: 8, padding: '10px 12px', color: '#fca5a5', fontSize: 13, marginBottom: 14 }}>
+              {loginError}
+            </div>
+          )}
+
+          <button
+            type="submit"
+            style={{ width: '100%', background: '#F7A62D', color: '#1c1917', fontFamily: "'Space Grotesk', sans-serif", fontWeight: 800, fontSize: 16, letterSpacing: '0.06em', textTransform: 'uppercase', border: 'none', borderRadius: 12, padding: 16, cursor: 'pointer' }}
+          >
+            Let's Go ↗
+          </button>
+        </form>
+
+        <div style={{ textAlign: 'center', padding: '16px 0 28px', fontSize: 13, color: 'rgba(255,255,255,0.35)' }}>
+          First time?{' '}
+          <Link to="/signup" style={{ color: '#F7A62D', fontWeight: 700, textDecoration: 'none' }}>Create account</Link>
+        </div>
       </div>
     </div>
+  );
+
+  /* ── DESKTOP layout (≥ 768px) ── */
+  const DesktopLayout = () => (
+    <div style={{ display: 'flex', height: '100dvh', fontFamily: "'Space Grotesk', sans-serif", background: '#fafaf9', overflow: 'hidden' }}>
+      {/* Left hero panel */}
+      <div style={{ width: 560, flexShrink: 0, background: '#fafaf9', position: 'relative', overflow: 'hidden', display: 'flex', flexDirection: 'column', justifyContent: 'flex-end', padding: '52px 52px 56px' }}>
+        <Blob style={{ width: 280, height: 280, top: -80, right: -80, opacity: 0.13 }} />
+        <Blob style={{ width: 100, height: 70, top: '42%', left: -24, opacity: 0.09, borderRadius: '30% 60%', transform: 'rotate(15deg)' }} />
+        <Blob style={{ width: 50, height: 36, top: '32%', right: 120, opacity: 0.17, borderRadius: '50% 30%', transform: 'rotate(-20deg)' }} />
+        <Blob style={{ width: 44, height: 30, bottom: 120, right: 60, opacity: 0.12, borderRadius: '40% 60%', transform: 'rotate(10deg)' }} />
+
+        {/* Brand */}
+        <div style={{ display: 'flex', alignItems: 'center', gap: 12, position: 'absolute', top: 48, left: 52, zIndex: 2 }}>
+          <img src="/climbge.png" style={{ width: 36, height: 36, objectFit: 'contain' }} alt="logo" />
+          <span style={{ fontFamily: "'Bebas Neue', sans-serif", fontSize: 24, letterSpacing: '0.1em', color: '#1c1917' }}>CLIMBGE</span>
+        </div>
+
+        <div style={{ fontFamily: "'Bebas Neue', sans-serif", fontSize: 124, lineHeight: 0.85, color: '#1c1917', position: 'relative', zIndex: 2 }}>
+          CLIMB<br /><span style={{ color: '#F7A62D' }}>MORE.</span><br />LOG IT.
+        </div>
+        <div style={{ fontSize: 15, fontWeight: 500, color: '#78716c', marginTop: 16, position: 'relative', zIndex: 2, lineHeight: 1.5 }}>
+          Sign back in to continue tracking your sends, streaks, and progress.
+        </div>
+      </div>
+
+      {/* Right form panel */}
+      <div style={{ flex: 1, background: '#1c1917', display: 'flex', flexDirection: 'column', justifyContent: 'center', overflowY: 'auto', padding: '52px 56px' }}>
+        <div style={{ fontFamily: "'Bebas Neue', sans-serif", fontSize: 42, color: '#fff', letterSpacing: '0.06em', marginBottom: 28 }}>SIGN IN</div>
+
+        <form onSubmit={handleLogin}>
+          <label style={labelStyle}>Username</label>
+          <div style={{ position: 'relative', marginBottom: 14 }}>
+            <span style={iconStyle}>◉</span>
+            <input
+              style={inputStyle}
+              type="text"
+              placeholder="your handle"
+              value={username}
+              onChange={(e) => setUsername(e.target.value)}
+              onFocus={(e) => (e.target.style.borderColor = 'rgba(247,166,45,0.5)')}
+              onBlur={(e) => (e.target.style.borderColor = 'rgba(255,255,255,0.1)')}
+            />
+          </div>
+
+          <label style={labelStyle}>Password</label>
+          <div style={{ position: 'relative', marginBottom: 28 }}>
+            <span style={iconStyle}>◈</span>
+            <input
+              style={{ ...inputStyle, paddingRight: 42 }}
+              type={showPassword ? 'text' : 'password'}
+              placeholder="••••••••"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              onFocus={(e) => (e.target.style.borderColor = 'rgba(247,166,45,0.5)')}
+              onBlur={(e) => (e.target.style.borderColor = 'rgba(255,255,255,0.1)')}
+            />
+            <button
+              type="button"
+              onClick={() => setShowPassword((s) => !s)}
+              style={{ position: 'absolute', right: 14, top: '50%', transform: 'translateY(-50%)', background: 'none', border: 'none', cursor: 'pointer', color: 'rgba(255,255,255,0.4)', padding: 0, display: 'flex', alignItems: 'center' }}
+              aria-label={showPassword ? 'Hide password' : 'Show password'}
+            >
+              {showPassword ? <EyeOff size={16} /> : <Eye size={16} />}
+            </button>
+          </div>
+
+          {loginError && (
+            <div style={{ background: 'rgba(239,68,68,0.12)', border: '1px solid rgba(239,68,68,0.3)', borderRadius: 8, padding: '10px 12px', color: '#fca5a5', fontSize: 13, marginBottom: 14 }}>
+              {loginError}
+            </div>
+          )}
+
+          <div style={{ display: 'flex', gap: 16, alignItems: 'center' }}>
+            <button
+              type="submit"
+              style={{ flex: 1, background: '#F7A62D', color: '#1c1917', fontFamily: "'Space Grotesk', sans-serif", fontWeight: 800, fontSize: 16, letterSpacing: '0.06em', textTransform: 'uppercase', border: 'none', borderRadius: 12, padding: 16, cursor: 'pointer' }}
+            >
+              Let's Go ↗
+            </button>
+            <div style={{ fontSize: 13, color: 'rgba(255,255,255,0.35)', whiteSpace: 'nowrap' }}>
+              No account?{' '}
+              <Link to="/signup" style={{ color: '#F7A62D', fontWeight: 700, textDecoration: 'none' }}>Sign up free</Link>
+            </div>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+
+  return (
+    <>
+      {/* Mobile */}
+      <div className="block md:hidden">
+        <MobileLayout />
+      </div>
+      {/* Desktop */}
+      <div className="hidden md:block">
+        <DesktopLayout />
+      </div>
+    </>
   );
 }

--- a/frontend/src/SignupPage.tsx
+++ b/frontend/src/SignupPage.tsx
@@ -1,15 +1,31 @@
 import { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { apiSignup } from './lib/api';
-import { Mountain, User, Lock, Eye, EyeOff, Calendar, MapPin, Mail } from 'lucide-react';
+import { Eye, EyeOff } from 'lucide-react';
 import type { SignUpData, UserProfile } from './types/user';
 
 interface SignupPageProps {
   onSignup: (userProfile: UserProfile) => void;
 }
 
+function Blob({ style }: { style: React.CSSProperties }) {
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        background: '#F7A62D',
+        borderRadius: '50%',
+        pointerEvents: 'none',
+        zIndex: 1,
+        ...style,
+      }}
+    />
+  );
+}
+
 export function SignupPage({ onSignup }: SignupPageProps) {
   const navigate = useNavigate();
+  const [step, setStep] = useState(0); // mobile: 0 = required, 1 = optional
   const [showPw, setShowPw] = useState(false);
   const [showPw2, setShowPw2] = useState(false);
   const [error, setError] = useState('');
@@ -29,33 +45,38 @@ export function SignupPage({ onSignup }: SignupPageProps) {
 
   const startedMax = new Date().toISOString().slice(0, 7);
 
+  const set = (field: keyof SignUpData) => (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) =>
+    setData((p) => ({ ...p, [field]: e.target.value }));
+
+  const validateStep1 = () => {
+    if (!data.username.trim()) return setError('Please enter a username'), false;
+    if (data.username.length < 3) return setError('Username must be at least 3 characters'), false;
+    if (!data.password.trim()) return setError('Please enter a password'), false;
+    if (data.password.length < 6) return setError('Password must be at least 6 characters'), false;
+    if (data.password !== data.confirmPassword) return setError('Passwords do not match'), false;
+    if (!data.startedClimbing) return setError('Please select when you started climbing'), false;
+    return true;
+  };
+
+  const handleMobileNext = () => {
+    setError('');
+    if (validateStep1()) setStep(1);
+  };
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError('');
-
-    if (!data.username.trim()) return setError('Please enter a username');
-    if (data.username.length < 3) return setError('Username must be at least 3 characters long');
-    if (!data.password.trim()) return setError('Please enter a password');
-    if (data.password.length < 6) return setError('Password must be at least 6 characters long');
-    if (data.password !== data.confirmPassword) return setError('Passwords do not match');
-    if (!data.startedClimbing) return setError('Please select when you started climbing');
-
+    if (!validateStep1()) return;
     const started = `${data.startedClimbing}-01`;
-
     try {
-      const res = await apiSignup(
-        data.username.trim(),
-        data.password,
-        started,
-        {
-          email: data.email || undefined,
-          name: data.name || undefined,
-          age: data.age || undefined,
-          sex: data.sex || undefined,
-          homeCity: data.homeCity || undefined,
-          homeGym: data.homeGym || undefined,
-        }
-      );
+      const res = await apiSignup(data.username.trim(), data.password, started, {
+        email: data.email || undefined,
+        name: data.name || undefined,
+        age: data.age || undefined,
+        sex: data.sex || undefined,
+        homeCity: data.homeCity || undefined,
+        homeGym: data.homeGym || undefined,
+      });
       onSignup(res.profile);
       navigate('/', { replace: true });
     } catch (err: unknown) {
@@ -64,128 +85,300 @@ export function SignupPage({ onSignup }: SignupPageProps) {
     }
   };
 
-  return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50 px-4">
-      <div className="w-full max-w-md bg-white rounded-xl shadow-lg p-6 space-y-6">
+  /* ── shared inline styles ── */
+  const inputStyle: React.CSSProperties = {
+    width: '100%',
+    background: 'rgba(255,255,255,0.07)',
+    border: '1px solid rgba(255,255,255,0.1)',
+    borderRadius: 10,
+    padding: '13px 14px 13px 42px',
+    color: '#fff',
+    fontSize: 15,
+    fontFamily: "'Space Grotesk', sans-serif",
+    outline: 'none',
+  };
 
-        {/* Header */}
-        <div className="text-center space-y-2">
-          <div className="mx-auto w-16 h-16 bg-brand rounded-full flex items-center justify-center">
-            <Mountain className="h-8 w-8 text-white" />
-          </div>
-          <h1 className="text-2xl font-bold text-gray-800">Create your account</h1>
-          <p className="text-gray-500 text-sm">Start tracking your climbing progress!</p>
+  const labelStyle: React.CSSProperties = {
+    fontSize: 10,
+    fontWeight: 700,
+    letterSpacing: '0.16em',
+    textTransform: 'uppercase',
+    color: 'rgba(255,255,255,0.4)',
+    marginBottom: 6,
+    display: 'block',
+  };
+
+  const iconStyle: React.CSSProperties = {
+    position: 'absolute',
+    left: 14,
+    top: '50%',
+    transform: 'translateY(-50%)',
+    fontSize: 14,
+    color: 'rgba(247,166,45,0.65)',
+    pointerEvents: 'none',
+  };
+
+  const focusHandlers = {
+    onFocus: (e: React.FocusEvent<HTMLInputElement | HTMLSelectElement>) =>
+      (e.target.style.borderColor = 'rgba(247,166,45,0.5)'),
+    onBlur: (e: React.FocusEvent<HTMLInputElement | HTMLSelectElement>) =>
+      (e.target.style.borderColor = 'rgba(255,255,255,0.1)'),
+  };
+
+  const ctaStyle: React.CSSProperties = {
+    width: '100%',
+    background: '#F7A62D',
+    color: '#1c1917',
+    fontFamily: "'Space Grotesk', sans-serif",
+    fontWeight: 800,
+    fontSize: 16,
+    letterSpacing: '0.06em',
+    textTransform: 'uppercase',
+    border: 'none',
+    borderRadius: 12,
+    padding: 16,
+    cursor: 'pointer',
+  };
+
+  /* ── MOBILE ── */
+  const MobileLayout = () => (
+    <div style={{ display: 'flex', flexDirection: 'column', minHeight: '100dvh', background: '#fafaf9', fontFamily: "'Space Grotesk', sans-serif", overflow: 'hidden' }}>
+      {/* Hero top */}
+      <div style={{ position: 'relative', flexShrink: 0, overflow: 'hidden', padding: '44px 32px 14px' }}>
+        <Blob style={{ width: 140, height: 140, top: -50, right: -40, opacity: 0.12 }} />
+        <Blob style={{ width: 44, height: 30, top: '38%', right: 80, opacity: 0.15, borderRadius: '50% 30%', transform: 'rotate(20deg)' }} />
+
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 24, position: 'relative', zIndex: 2 }}>
+          <img src="/climbge.png" style={{ width: 32, height: 32, objectFit: 'contain' }} alt="climbge logo" />
+          <span style={{ fontFamily: "'Bebas Neue', sans-serif", fontSize: 20, letterSpacing: '0.12em', color: '#1c1917' }}>CLIMBGE</span>
         </div>
 
-        {/* Form */}
-        <form onSubmit={handleSubmit} className="space-y-4">
-          {/* Username */}
-          <div>
-            <label className="block text-sm font-medium text-gray-700">Username</label>
-            <div className="relative mt-1">
-              <User className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
-              <input
-                type="text"
-                value={data.username}
-                onChange={(e) => setData((p) => ({ ...p, username: e.target.value }))}
-                placeholder="Pick a username"
-                className="w-full pl-10 pr-3 py-2 border rounded-lg focus:ring-2 focus:ring-brand focus:outline-none"
-              />
-            </div>
-          </div>
+        <div style={{ fontFamily: "'Bebas Neue', sans-serif", fontSize: 'clamp(60px, 18vw, 68px)', lineHeight: 0.87, color: '#1c1917', position: 'relative', zIndex: 2 }}>
+          JOIN<br />THE<br /><span style={{ color: '#F7A62D' }}>WALL.</span>
+        </div>
+        <div style={{ fontSize: 13, fontWeight: 500, color: '#78716c', marginTop: 12, position: 'relative', zIndex: 2 }}>
+          Start tracking every send.
+        </div>
+      </div>
 
-          {/* Password */}
-          <div>
-            <label className="block text-sm font-medium text-gray-700">Password</label>
-            <div className="relative mt-1">
-              <Lock className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
-              <input
-                type={showPw ? 'text' : 'password'}
-                value={data.password}
-                onChange={(e) => setData((p) => ({ ...p, password: e.target.value }))}
-                placeholder="Create a password"
-                className="w-full pl-10 pr-10 py-2 border rounded-lg focus:ring-2 focus:ring-brand focus:outline-none"
-              />
-              <button
-                type="button"
-                onClick={() => setShowPw((v) => !v)}
-                className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400"
-              >
-                {showPw ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+      {/* Dark form sheet */}
+      <div style={{ flex: 1, background: '#1c1917', borderRadius: '28px 28px 0 0', padding: '24px 28px 0', overflowY: 'auto' }}>
+        {/* Step indicator */}
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 20 }}>
+          <div style={{ flex: 1, height: 3, borderRadius: 2, background: '#F7A62D', transition: 'background 0.3s' }} />
+          <div style={{ flex: 1, height: 3, borderRadius: 2, background: step >= 1 ? '#F7A62D' : 'rgba(255,255,255,0.1)', transition: 'background 0.3s' }} />
+          <span style={{ fontSize: 11, fontWeight: 600, letterSpacing: '0.1em', textTransform: 'uppercase', color: 'rgba(255,255,255,0.35)', whiteSpace: 'nowrap' }}>
+            Step {step + 1} of 2
+          </span>
+        </div>
+
+        {step === 0 ? (
+          <>
+            <label style={labelStyle}>Username <span style={{ color: '#ef4444' }}>*</span></label>
+            <div style={{ position: 'relative', marginBottom: 14 }}>
+              <span style={iconStyle}>◉</span>
+              <input style={inputStyle} type="text" placeholder="pick a handle" value={data.username} onChange={set('username')} {...focusHandlers} />
+            </div>
+
+            <label style={labelStyle}>Password <span style={{ color: '#ef4444' }}>*</span></label>
+            <div style={{ position: 'relative', marginBottom: 14 }}>
+              <span style={iconStyle}>◈</span>
+              <input style={{ ...inputStyle, paddingRight: 42 }} type={showPw ? 'text' : 'password'} placeholder="min 6 characters" value={data.password} onChange={set('password')} {...focusHandlers} />
+              <button type="button" onClick={() => setShowPw((v) => !v)} style={{ position: 'absolute', right: 14, top: '50%', transform: 'translateY(-50%)', background: 'none', border: 'none', cursor: 'pointer', color: 'rgba(255,255,255,0.4)', display: 'flex' }}>
+                {showPw ? <EyeOff size={16} /> : <Eye size={16} />}
               </button>
             </div>
-          </div>
 
-          {/* Confirm Password */}
-          <div>
-            <label className="block text-sm font-medium text-gray-700">Confirm Password</label>
-            <div className="relative mt-1">
-              <Lock className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
-              <input
-                type={showPw2 ? 'text' : 'password'}
-                value={data.confirmPassword}
-                onChange={(e) => setData((p) => ({ ...p, confirmPassword: e.target.value }))}
-                placeholder="Re-enter your password"
-                className="w-full pl-10 pr-10 py-2 border rounded-lg focus:ring-2 focus:ring-brand focus:outline-none"
-              />
-              <button
-                type="button"
-                onClick={() => setShowPw2((v) => !v)}
-                className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400"
-              >
-                {showPw2 ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+            <label style={labelStyle}>Confirm Password <span style={{ color: '#ef4444' }}>*</span></label>
+            <div style={{ position: 'relative', marginBottom: 14 }}>
+              <span style={iconStyle}>◈</span>
+              <input style={{ ...inputStyle, paddingRight: 42 }} type={showPw2 ? 'text' : 'password'} placeholder="re-enter password" value={data.confirmPassword} onChange={set('confirmPassword')} {...focusHandlers} />
+              <button type="button" onClick={() => setShowPw2((v) => !v)} style={{ position: 'absolute', right: 14, top: '50%', transform: 'translateY(-50%)', background: 'none', border: 'none', cursor: 'pointer', color: 'rgba(255,255,255,0.4)', display: 'flex' }}>
+                {showPw2 ? <EyeOff size={16} /> : <Eye size={16} />}
               </button>
             </div>
-          </div>
 
-          {/* Started Climbing */}
-          <div>
-            <label className="block text-sm font-medium text-gray-700">When did you start climbing?</label>
-            <div className="relative mt-1">
-              <Calendar className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
-              <input
-                type="month"
-                value={data.startedClimbing}
-                onChange={(e) => setData((p) => ({ ...p, startedClimbing: e.target.value }))}
-                max={startedMax}
-                className="w-full pl-10 pr-3 py-2 border rounded-lg focus:ring-2 focus:ring-brand focus:outline-none"
-              />
+            <label style={labelStyle}>Started Climbing <span style={{ color: '#ef4444' }}>*</span></label>
+            <div style={{ position: 'relative', marginBottom: 14 }}>
+              <span style={iconStyle}>◷</span>
+              <input style={{ ...inputStyle, colorScheme: 'dark' }} type="month" max={startedMax} value={data.startedClimbing} onChange={set('startedClimbing')} {...focusHandlers} />
             </div>
-          </div>
 
-          {/* Optional Fields */}
-          {[
-            { id: 'email', label: 'Email', icon: Mail, type: 'email' },
-            { id: 'name', label: 'Name', icon: User, type: 'text' },
-            { id: 'age', label: 'Age', icon: Calendar, type: 'number' },
-            { id: 'homeCity', label: 'Home City', icon: MapPin, type: 'text' },
-            { id: 'homeGym', label: 'Primary Climbing Gym', icon: Mountain, type: 'text' }
-          ].map(({ id, label, icon: Icon, type }) => (
-            <div key={id}>
-              <label className="block text-sm font-medium text-gray-700">{label}</label>
-              <div className="relative mt-1">
-                <Icon className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
-                <input
-                  type={type}
-                  value={(data as any)[id] || ''}
-                  onChange={(e) => setData((p) => ({ ...p, [id]: e.target.value }))}
-                  placeholder="Optional"
-                  className="w-full pl-10 pr-3 py-2 border rounded-lg focus:ring-2 focus:ring-brand focus:outline-none"
-                />
+            {error && <div style={{ background: 'rgba(239,68,68,0.12)', border: '1px solid rgba(239,68,68,0.3)', borderRadius: 8, padding: '10px 12px', color: '#fca5a5', fontSize: 13, marginBottom: 14 }}>{error}</div>}
+
+            <div style={{ marginBottom: 20 }} />
+            <button type="button" onClick={handleMobileNext} style={ctaStyle}>Next →</button>
+            <div style={{ textAlign: 'center', padding: '16px 0 28px', fontSize: 13, color: 'rgba(255,255,255,0.35)' }}>
+              Already have an account?{' '}<Link to="/login" style={{ color: '#F7A62D', fontWeight: 700, textDecoration: 'none' }}>Sign in</Link>
+            </div>
+          </>
+        ) : (
+          <form onSubmit={handleSubmit}>
+            <div style={{ marginBottom: 14 }}>
+              <span style={{ ...labelStyle, display: 'inline', marginBottom: 0 }}>Profile Details</span>
+              <span style={{ display: 'inline-block', fontSize: 9, fontWeight: 700, letterSpacing: '0.12em', textTransform: 'uppercase', background: 'rgba(247,166,45,0.15)', color: '#F7A62D', borderRadius: 4, padding: '2px 6px', marginLeft: 6 }}>Optional</span>
+            </div>
+            <div style={{ marginBottom: 14 }} />
+
+            <label style={labelStyle}>Email</label>
+            <div style={{ position: 'relative', marginBottom: 14 }}>
+              <span style={iconStyle}>@</span>
+              <input style={inputStyle} type="email" placeholder="your@email.com" value={data.email} onChange={set('email')} {...focusHandlers} />
+            </div>
+
+            <label style={labelStyle}>Name</label>
+            <div style={{ position: 'relative', marginBottom: 14 }}>
+              <span style={iconStyle}>◉</span>
+              <input style={inputStyle} type="text" placeholder="your name" value={data.name} onChange={set('name')} {...focusHandlers} />
+            </div>
+
+            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '0 12px' }}>
+              <div>
+                <label style={labelStyle}>Age</label>
+                <div style={{ position: 'relative', marginBottom: 14 }}>
+                  <span style={iconStyle}>#</span>
+                  <input style={inputStyle} type="number" placeholder="—" value={data.age} onChange={set('age')} {...focusHandlers} />
+                </div>
+              </div>
+              <div>
+                <label style={labelStyle}>Sex</label>
+                <div style={{ position: 'relative', marginBottom: 14 }}>
+                  <span style={iconStyle}>▾</span>
+                  <select style={{ ...inputStyle, appearance: 'none', cursor: 'pointer', color: data.sex ? '#fff' : 'rgba(255,255,255,0.2)' }} value={data.sex} onChange={set('sex')} {...focusHandlers}>
+                    <option value="">—</option>
+                    <option value="male">Male</option>
+                    <option value="female">Female</option>
+                    <option value="other">Other</option>
+                  </select>
+                </div>
               </div>
             </div>
-          ))}
 
-          {/* Sex */}
+            <label style={labelStyle}>Home City</label>
+            <div style={{ position: 'relative', marginBottom: 14 }}>
+              <span style={iconStyle}>◎</span>
+              <input style={inputStyle} type="text" placeholder="city, country" value={data.homeCity} onChange={set('homeCity')} {...focusHandlers} />
+            </div>
+
+            <label style={labelStyle}>Primary Gym</label>
+            <div style={{ position: 'relative', marginBottom: 20 }}>
+              <span style={iconStyle}>⌂</span>
+              <input style={inputStyle} type="text" placeholder="your gym's name" value={data.homeGym} onChange={set('homeGym')} {...focusHandlers} />
+            </div>
+
+            {error && <div style={{ background: 'rgba(239,68,68,0.12)', border: '1px solid rgba(239,68,68,0.3)', borderRadius: 8, padding: '10px 12px', color: '#fca5a5', fontSize: 13, marginBottom: 14 }}>{error}</div>}
+
+            <button type="submit" style={ctaStyle}>Create Account ↗</button>
+            <div style={{ textAlign: 'center', padding: '16px 0 28px', fontSize: 13, color: 'rgba(255,255,255,0.35)' }}>
+              <span style={{ cursor: 'pointer', color: 'rgba(255,255,255,0.4)' }} onClick={() => { setStep(0); setError(''); }}>← back</span>
+              {'  ·  '}
+              <Link to="/login" style={{ color: '#F7A62D', fontWeight: 700, textDecoration: 'none' }}>Already have an account?</Link>
+            </div>
+          </form>
+        )}
+      </div>
+    </div>
+  );
+
+  /* ── DESKTOP ── */
+  const DesktopLayout = () => (
+    <div style={{ display: 'flex', height: '100dvh', fontFamily: "'Space Grotesk', sans-serif", background: '#fafaf9', overflow: 'hidden' }}>
+      {/* Left hero panel */}
+      <div style={{ width: 480, flexShrink: 0, background: '#fafaf9', position: 'relative', overflow: 'hidden', display: 'flex', flexDirection: 'column', justifyContent: 'flex-end', padding: '52px 52px 56px' }}>
+        <Blob style={{ width: 220, height: 220, top: -60, right: -60, opacity: 0.12 }} />
+        <Blob style={{ width: 70, height: 50, top: '44%', left: -18, opacity: 0.09, borderRadius: '30% 60%', transform: 'rotate(15deg)' }} />
+        <Blob style={{ width: 40, height: 28, top: '30%', right: 100, opacity: 0.16, borderRadius: '50% 30%', transform: 'rotate(-20deg)' }} />
+
+        <div style={{ display: 'flex', alignItems: 'center', gap: 12, position: 'absolute', top: 48, left: 52, zIndex: 2 }}>
+          <img src="/climbge.png" style={{ width: 36, height: 36, objectFit: 'contain' }} alt="logo" />
+          <span style={{ fontFamily: "'Bebas Neue', sans-serif", fontSize: 24, letterSpacing: '0.1em', color: '#1c1917' }}>CLIMBGE</span>
+        </div>
+
+        <div style={{ fontFamily: "'Bebas Neue', sans-serif", fontSize: 100, lineHeight: 0.85, color: '#1c1917', position: 'relative', zIndex: 2 }}>
+          JOIN<br />THE<br /><span style={{ color: '#F7A62D' }}>WALL.</span>
+        </div>
+        <div style={{ fontSize: 15, fontWeight: 500, color: '#78716c', marginTop: 16, position: 'relative', zIndex: 2, lineHeight: 1.5 }}>
+          Track every send. See your grade progression. Build your streak.
+        </div>
+      </div>
+
+      {/* Right form panel */}
+      <form onSubmit={handleSubmit} style={{ flex: 1, background: '#1c1917', display: 'flex', flexDirection: 'column', justifyContent: 'center', overflowY: 'auto', padding: '52px 48px' }}>
+        <div style={{ fontFamily: "'Bebas Neue', sans-serif", fontSize: 42, color: '#fff', letterSpacing: '0.06em', marginBottom: 20 }}>CREATE ACCOUNT</div>
+
+        {/* Required section */}
+        <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: '0.16em', textTransform: 'uppercase', color: 'rgba(255,255,255,0.4)', marginBottom: 10 }}>Required</div>
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '0 20px' }}>
           <div>
-            <label className="block text-sm font-medium text-gray-700">Sex</label>
-            <div className="relative mt-1">
-              <User className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
-              <select
-                value={data.sex || ''}
-                onChange={(e) => setData((p) => ({ ...p, sex: e.target.value }))}
-                className="w-full pl-10 pr-3 py-2 border rounded-lg focus:ring-2 focus:ring-brand focus:outline-none"
-              >
+            <label style={labelStyle}>Username</label>
+            <div style={{ position: 'relative', marginBottom: 12 }}>
+              <span style={iconStyle}>◉</span>
+              <input style={inputStyle} type="text" placeholder="pick a handle" value={data.username} onChange={set('username')} {...focusHandlers} />
+            </div>
+          </div>
+          <div>
+            <label style={labelStyle}>Started Climbing</label>
+            <div style={{ position: 'relative', marginBottom: 12 }}>
+              <span style={iconStyle}>◷</span>
+              <input style={{ ...inputStyle, colorScheme: 'dark' }} type="month" max={startedMax} value={data.startedClimbing} onChange={set('startedClimbing')} {...focusHandlers} />
+            </div>
+          </div>
+          <div>
+            <label style={labelStyle}>Password</label>
+            <div style={{ position: 'relative', marginBottom: 12 }}>
+              <span style={iconStyle}>◈</span>
+              <input style={{ ...inputStyle, paddingRight: 42 }} type={showPw ? 'text' : 'password'} placeholder="min 6 chars" value={data.password} onChange={set('password')} {...focusHandlers} />
+              <button type="button" onClick={() => setShowPw((v) => !v)} style={{ position: 'absolute', right: 14, top: '50%', transform: 'translateY(-50%)', background: 'none', border: 'none', cursor: 'pointer', color: 'rgba(255,255,255,0.4)', display: 'flex' }}>
+                {showPw ? <EyeOff size={16} /> : <Eye size={16} />}
+              </button>
+            </div>
+          </div>
+          <div>
+            <label style={labelStyle}>Confirm Password</label>
+            <div style={{ position: 'relative', marginBottom: 12 }}>
+              <span style={iconStyle}>◈</span>
+              <input style={{ ...inputStyle, paddingRight: 42 }} type={showPw2 ? 'text' : 'password'} placeholder="re-enter" value={data.confirmPassword} onChange={set('confirmPassword')} {...focusHandlers} />
+              <button type="button" onClick={() => setShowPw2((v) => !v)} style={{ position: 'absolute', right: 14, top: '50%', transform: 'translateY(-50%)', background: 'none', border: 'none', cursor: 'pointer', color: 'rgba(255,255,255,0.4)', display: 'flex' }}>
+                {showPw2 ? <EyeOff size={16} /> : <Eye size={16} />}
+              </button>
+            </div>
+          </div>
+        </div>
+
+        {/* Optional divider */}
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10, margin: '8px 0 12px' }}>
+          <div style={{ flex: 1, height: 1, background: 'rgba(255,255,255,0.08)' }} />
+          <span style={{ fontSize: 10, letterSpacing: '0.12em', textTransform: 'uppercase', color: 'rgba(255,255,255,0.25)', fontWeight: 600 }}>Optional details</span>
+          <div style={{ flex: 1, height: 1, background: 'rgba(255,255,255,0.08)' }} />
+        </div>
+
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '0 20px' }}>
+          <div>
+            <label style={labelStyle}>Email</label>
+            <div style={{ position: 'relative', marginBottom: 12 }}>
+              <span style={iconStyle}>@</span>
+              <input style={inputStyle} type="email" placeholder="your@email.com" value={data.email} onChange={set('email')} {...focusHandlers} />
+            </div>
+          </div>
+          <div>
+            <label style={labelStyle}>Name</label>
+            <div style={{ position: 'relative', marginBottom: 12 }}>
+              <span style={iconStyle}>◉</span>
+              <input style={inputStyle} type="text" placeholder="your name" value={data.name} onChange={set('name')} {...focusHandlers} />
+            </div>
+          </div>
+          <div>
+            <label style={labelStyle}>Age</label>
+            <div style={{ position: 'relative', marginBottom: 12 }}>
+              <span style={iconStyle}>#</span>
+              <input style={inputStyle} type="number" placeholder="—" value={data.age} onChange={set('age')} {...focusHandlers} />
+            </div>
+          </div>
+          <div>
+            <label style={labelStyle}>Sex</label>
+            <div style={{ position: 'relative', marginBottom: 12 }}>
+              <span style={iconStyle}>▾</span>
+              <select style={{ ...inputStyle, appearance: 'none', cursor: 'pointer', color: data.sex ? '#fff' : 'rgba(255,255,255,0.2)' }} value={data.sex} onChange={set('sex')} {...focusHandlers}>
                 <option value="">Prefer not to say</option>
                 <option value="male">Male</option>
                 <option value="female">Female</option>
@@ -193,34 +386,42 @@ export function SignupPage({ onSignup }: SignupPageProps) {
               </select>
             </div>
           </div>
+          <div>
+            <label style={labelStyle}>Home City</label>
+            <div style={{ position: 'relative', marginBottom: 12 }}>
+              <span style={iconStyle}>◎</span>
+              <input style={inputStyle} type="text" placeholder="city, country" value={data.homeCity} onChange={set('homeCity')} {...focusHandlers} />
+            </div>
+          </div>
+          <div>
+            <label style={labelStyle}>Primary Gym</label>
+            <div style={{ position: 'relative', marginBottom: 12 }}>
+              <span style={iconStyle}>⌂</span>
+              <input style={inputStyle} type="text" placeholder="your gym's name" value={data.homeGym} onChange={set('homeGym')} {...focusHandlers} />
+            </div>
+          </div>
+        </div>
 
-          {/* Error */}
-          {error && <p className="text-red-500 text-sm">{error}</p>}
+        {error && <div style={{ background: 'rgba(239,68,68,0.12)', border: '1px solid rgba(239,68,68,0.3)', borderRadius: 8, padding: '10px 12px', color: '#fca5a5', fontSize: 13, marginBottom: 12 }}>{error}</div>}
 
-          {/* Actions */}
-          <button
-            type="submit"
-            className="w-full bg-brand hover:bg-brand-dark text-white py-2 rounded-lg font-medium"
-          >
-            Create Account
-          </button>
-          <button
-            type="button"
-            onClick={() => navigate('/login')}
-            className="w-full mt-2 border border-gray-300 py-2 rounded-lg font-medium text-gray-700 hover:bg-gray-100"
-          >
-            Back to Login
-          </button>
-
-          {/* Already have account */}
-          <p className="text-center text-sm text-gray-500 mt-4">
-            Already have an account?{' '}
-            <Link to="/login" className="text-brand hover:underline">
-              Sign in
-            </Link>
-          </p>
-        </form>
-      </div>
+        <div style={{ marginTop: 8, display: 'flex', gap: 16, alignItems: 'center' }}>
+          <button type="submit" style={{ ...ctaStyle, flex: 1 }}>Create Account ↗</button>
+          <div style={{ fontSize: 13, color: 'rgba(255,255,255,0.35)', whiteSpace: 'nowrap' }}>
+            Have an account?{' '}<Link to="/login" style={{ color: '#F7A62D', fontWeight: 700, textDecoration: 'none' }}>Sign in</Link>
+          </div>
+        </div>
+      </form>
     </div>
+  );
+
+  return (
+    <>
+      <div className="block md:hidden">
+        <MobileLayout />
+      </div>
+      <div className="hidden md:block">
+        <DesktopLayout />
+      </div>
+    </>
   );
 }


### PR DESCRIPTION
**Login page** — both mobile and desktop, pixel-faithful to the "Chalk Blast B" design:

- **Mobile**: Light chalk-white top with the `CLIMB MORE. LOG IT.` Bebas Neue hero, decorative amber blobs, then a dark `#1c1917` bottom sheet slides up with the username/password form and amber CTA button
- **Desktop**: Vertical split — left panel has the full hero type at 124px, right dark panel has the `SIGN IN` form with a side-by-side CTA + link row

**Create Account page** — same Chalk Blast treatment:

- **Mobile**: 2-step flow — Step 1 collects required fields (username, passwords, started climbing) with an amber progress bar, Step 2 collects optional profile details (email, name, age, sex, city, gym)
- **Desktop**: Single-scroll form in a 2-column grid, divided by a subtle "Optional details" divider

Both pages are fully wired to the existing `apiLogin` / `apiSignup` calls and routing — nothing else in the app was touched.

[Chalk Blast Designs - Standalone.html](https://github.com/user-attachments/files/27315406/Chalk.Blast.Designs.-.Standalone.html)